### PR TITLE
Fix: Rename "tokenizer" to "subtokenizer"

### DIFF
--- a/week5_tokenization.ipynb
+++ b/week5_tokenization.ipynb
@@ -248,7 +248,7 @@
       "outputs": [],
       "source": [
         "subtokenizer = tf_text.WordpieceTokenizer(filepath)\n",
-        "subtokens = tokenizer.tokenize(tokens)\n",
+        "subtokens = subtokenizer.tokenize(tokens)\n",
         "print(subtokens.to_list())"
       ]
     },


### PR DESCRIPTION
Rename "tokenizer" to "subtokenizer" on the WordPieceTokener application